### PR TITLE
Устранено неравенство температур

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -26,7 +26,7 @@
     byte ext_temp_data[BYTE_ITERATOR];
     byte HighByte;
     byte LowByte; 
-    double external_temperature;
+    float external_temperature;
     byte tempInt; 
     byte tempFloat;
     Serial_measure _temp_ext;

--- a/tasks.h
+++ b/tasks.h
@@ -74,7 +74,7 @@
       tempInt = ((HighByte & 7)<<4)|(LowByte >> 4);
       tempFloat = (LowByte & 15);
 
-      external_temperature = tempInt + (tempFloat / 16);
+      external_temperature = (tempInt + (tempFloat / 16));
       _temp_ext.set_new_value(external_temperature);
   
 #endif


### PR DESCRIPTION
Устранено неравенство температур с датчиков DS18B20 и BME280 при одинаковых условиях. Проблема была в неявном преобразовании типов